### PR TITLE
fix: update HackerRank link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://www.kaggle.com/aastha124" target="_blank">
     <img alt="Kaggle" src="https://img.shields.io/badge/Kaggle-20BEFF?style=for-the-badge&logo=Kaggle&logoColor=white">
   </a>  
- <a href="https://www.hackerrank.com/aasthajha123/hackos" target="_blank">
+ <a href="https://www.hackerrank.com/aasthajha123" target="_blank">
     <img alt="HackerRank" src="https://img.shields.io/badge/-Hackerrank-2EC866?style=for-the-badge&logo=HackerRank&logoColor=white">
   </a>
 


### PR DESCRIPTION
The current link points to a page that no longer exists on the website (Error 404)